### PR TITLE
Correctly specify the icon file for the browser to identify

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Commons Mobile App</title>
-    <link rel="shortcut icon" type="image/png" href="/images/favicon.png" />
+    <link rel="shortcut icon" type="image/png" href="images/favicon.png" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"
         integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous" />
     <link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
The root of the website that goes live might not be the
current directory. So, expecting the 'images' folder to be
in the root is not valid.

Referencing the 'images' folder relatively fixes this issue.